### PR TITLE
simpleeval 1.0.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "simpleeval" %}
-{% set version = "1.0.3" %}
+{% set version = "1.0.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 67bbf246040ac3b57c29cf048657b9cf31d4e7b9d6659684daa08ca8f1e45829
+  sha256: 1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13806](https://anaconda.atlassian.net/browse/PKG-13806)
- [Upstream repository](https://github.com/danthedeckie/simpleeval/tree/1.0.7)
- [Upstream changelog/diff](https://github.com/danthedeckie/simpleeval/releases)

### Explanation of changes:

- New version and sha256


[PKG-13806]: https://anaconda.atlassian.net/browse/PKG-13806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ